### PR TITLE
enable get requests for all or one single membershipplan

### DIFF
--- a/controllers/membershipPlans.js
+++ b/controllers/membershipPlans.js
@@ -1,5 +1,6 @@
 const MembershipPlan = require("../models/membershipPlans.js");
 
+//create new membership plan (like 10er Karte, unlimited offer etc)
 const createMembershipPlan = async (req, res) => {
   try {
     const { title, price, totalCredits } = req.body;
@@ -15,6 +16,31 @@ const createMembershipPlan = async (req, res) => {
   }
 };
 
+// get all the available memberships
+const getMembershipPlans = async (req, res) => {
+  try {
+    const membershipplans = await MembershipPlan.find({});
+    res.json(membershipplans);
+  } catch (error) {
+    console.log(error);
+    res.status(500).send("Panic! At the disco??");
+  }
+};
+
+// get one single membership using the _id from mongodb
+const getMembershipPlan = async (req, res) => {
+  try {
+    const { id } = req.params;
+    const plan = await MembershipPlan.findById(id);
+    res.json(plan);
+  } catch (error) {
+    console.log(error);
+    res.status(500).send("Problem fetching this plan");
+  }
+};
+
 module.exports = {
   createMembershipPlan,
+  getMembershipPlans,
+  getMembershipPlan,
 };

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ app.use(cors());
 
 app.use("/", userRouter);
 app.use("/activities", activityRouter);
-app.use("/createplan", membershipPlanRouter);
+app.use("/plan", membershipPlanRouter);
 app.use("/memberships", userMembershipRouter);
 
 app.listen(port, () => {

--- a/routes/membershipPlans.js
+++ b/routes/membershipPlans.js
@@ -1,9 +1,14 @@
 const express = require("express");
 
-const { createMembershipPlan } = require("../controllers/membershipPlans.js");
+const {
+  createMembershipPlan,
+  getMembershipPlans,
+  getMembershipPlan,
+} = require("../controllers/membershipPlans.js");
 
 const membershipPlanRouter = express.Router();
-
-membershipPlanRouter.route("/").post(createMembershipPlan);
+membershipPlanRouter.get("/", getMembershipPlans); //gets all available memberships
+membershipPlanRouter.post("/create", createMembershipPlan); //create new membership
+membershipPlanRouter.get("/:id", getMembershipPlan); // gets one individual membership based on the _id
 
 module.exports = membershipPlanRouter;


### PR DESCRIPTION
changes to be checked: 
- new get request for /plan gets all the membershipPlans from the database
- new get request for /plan/:id gets the single membershipPlan from the databse. use the _id from one plan to test

- post request route was changed slightly and is now /plan/create - please double check it is still working as required. 